### PR TITLE
#2 - 실제 DB(mysql) 접근을 위한 프로퍼티 설정 및 테스트 설정 추가

### DIFF
--- a/stock-system/src/main/resources/application.yaml
+++ b/stock-system/src/main/resources/application.yaml
@@ -7,6 +7,10 @@ logging:
 
 spring:
   application.name: stock-system
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PW}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -15,3 +19,12 @@ spring:
     properties:
       hibernate.format_sql: true
   sql.init.mode: always
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE
+    username:
+    password:

--- a/stock-system/src/test/java/arile/toy/stocksystem/StockSystemApplicationTests.java
+++ b/stock-system/src/test/java/arile/toy/stocksystem/StockSystemApplicationTests.java
@@ -2,7 +2,9 @@ package arile.toy.stocksystem;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class StockSystemApplicationTests {
 


### PR DESCRIPTION
기본 프로필에서 부트 앱을 실행할 경우
실제 DB(mySQL)에 접근할 수 있도록
datasoruce 정보를 변경함.
그러나, 그대로 넣을 경우 암호, ID 등의 민감정보가
소스코드를 통해 깃헙에 유출되므로
시스템 환경변수 형식으로 추가.
로컬에서 이 부분을 동작하게 하려면
별도로 시스템 환경변수를 적절히 세팅해 줘야 함.
기본 프로필은 이제 환경변수를 바라보므로
환경변수 없이 테스트를 동작할 수 있게
기본 테스트에 'test' 프로필을 annotation으로 지정함.

This closes #3 