### PR TITLE
35. 동시 호가 체결 로직 추가 + 코드 재구성(가독성 목적)

### DIFF
--- a/stock-system/src/main/java/arile/toy/stocksystem/stockserver/trading/service/TradeMatchingService.java
+++ b/stock-system/src/main/java/arile/toy/stocksystem/stockserver/trading/service/TradeMatchingService.java
@@ -6,12 +6,12 @@ import arile.toy.stocksystem.stockserver.trading.dto.order.OrderDto;
 import arile.toy.stocksystem.stockserver.trading.dto.order.OrderQueueRegistry;
 import arile.toy.stocksystem.stockserver.trading.dto.order.OrderStatus;
 import arile.toy.stocksystem.stockserver.trading.dto.order.StockServerOrderResponseMessage;
+import arile.toy.stocksystem.stockserver.trading.dto.trade.TradeResult;
 import arile.toy.stocksystem.stockserver.trading.event.TradeResponseEvent;
-import arile.toy.stocksystem.stockserver.trading.event.publisher.RedisOrderResponseEventPublisher;
-import arile.toy.stocksystem.stockserver.trading.event.publisher.RedisTradeResponseEventPublisher;
 import arile.toy.stocksystem.stockserver.trading.event.publisher.TradeResponseEventPublisher;
 import arile.toy.stocksystem.stockserver.trading.repository.StockServerOrderResponseRepository;
 import arile.toy.stocksystem.stockserver.trading.repository.TradeCommand;
+import arile.toy.stocksystem.stockserver.useraccount.event.publisher.AccountUpdateEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +29,7 @@ public class TradeMatchingService {
     private final TradeResponseEventPublisher tradeResponseEventPublisher;
     private final StockServerOrderResponseRepository stockServerOrderResponseRepository;
     private final TradeCommand tradeCommand;
+    private final AccountUpdateEventPublisher accountUpdateEventPublisher;
 
     public void getExternalTickMessageAndTrade(TradePriceTickMessage tradePriceTickMessage) {
         ReentrantLock lock = stockLockRegistry.lock(tradePriceTickMessage.stockCode());
@@ -41,157 +42,229 @@ public class TradeMatchingService {
         }
     }
 
-    private void matchAndExecuteWithinLock(TradePriceTickMessage tradePriceTickMessage) {
-        String stockCode = tradePriceTickMessage.stockCode();
-        int tradePrice = tradePriceTickMessage.curPrice();
-        int leftQuantity = tradePriceTickMessage.tradingVolumeTick();
-        String tradingType = tradePriceTickMessage.tradingType(); // 1:BUY, 5:SELL
 
-        if (tradingType.equals("1")) { // BUY -> 모의 투자는 SELL
-            while (leftQuantity > 0) {
-                var sellOrderDto = orderQueueRegistry.pollSell(stockCode);
-                if (sellOrderDto == null) return;
+    private void matchAndExecuteWithinLock(TradePriceTickMessage tick) {
 
-                if (sellOrderDto.orderPrice() > tradePrice) {
-                    orderQueueRegistry.orderEnqueue(sellOrderDto);
-                    return;
-                }
+        String stockCode = tick.stockCode();
+        int tradePrice = tick.curPrice();
+        int leftQuantity = tick.tradingVolumeTick();
+        String tradingType = tick.tradingType();
 
-                int executable = Math.min(leftQuantity, sellOrderDto.remainingQuantity());
-
-                var tradeResult = tradeExecutionService.executeSellTrade(sellOrderDto, tradePrice, executable);
-
-                if (tradeResult != null) {
-
-                    int remainingQuantity = sellOrderDto.remainingQuantity() - executable;
-
-                    if (remainingQuantity > 0) {
-                        var reEnqueuedOrderDto = new OrderDto(sellOrderDto.orderId(),
-                                sellOrderDto.username(),
-                                sellOrderDto.stockCode(),
-                                sellOrderDto.orderType(),
-                                sellOrderDto.orderPrice(),
-                                sellOrderDto.orderQuantity(),
-                                remainingQuantity,
-                                OrderStatus.PARTIAL,
-                                sellOrderDto.orderTime());
-                        orderQueueRegistry.orderEnqueue(reEnqueuedOrderDto);
-                    }
-
-                    if (remainingQuantity == 0) {
-                        stockServerOrderResponseRepository.delete(sellOrderDto.username(), sellOrderDto.orderId());
-                    } else {
-                        stockServerOrderResponseRepository.update(tradeResult.tradeEntity().getUsername(),
-                                tradeResult.tradeEntity().getOrderId(),
-                                StockServerOrderResponseMessage.of(
-                                        sellOrderDto.orderId(),
-                                        sellOrderDto.username(),
-                                        sellOrderDto.stockCode(),
-                                        sellOrderDto.orderType(),
-                                        sellOrderDto.orderPrice(),
-                                        sellOrderDto.orderQuantity(),
-                                        remainingQuantity,
-                                        sellOrderDto.orderTime()
-                                ));
-                    }
-
-                    long tradeAmount = (long) sellOrderDto.orderPrice() * tradeResult.tradeEntity().getTradeQuantity();
-                    long differenceAmount = (long) (tradeResult.tradeEntity().getTradePrice() - sellOrderDto.orderPrice()) * tradeResult.tradeEntity().getTradeQuantity();
-
-                    long buyPrice = 0;
-                    if (tradeResult.totalQuantity() != 0) {
-                        buyPrice = tradeResult.totalAmount() / tradeResult.totalQuantity();
-                    }
-
-                    boolean redisOk = tradeCommand.applySellTrade(
-                            tradeResult.tradeEntity().getUsername(),
-                            tradeResult.tradeEntity().getStockCode(),
-                            tradeResult.totalQuantity(),
-                            buyPrice,
-                            tradeAmount,
-                            differenceAmount
-                    );
-
-                    if (!redisOk) {
-                        log.error("Redis sell command failed.");
-                    }
-
-                    tradeResponseEventPublisher.publish(TradeResponseEvent.fromEntity(tradeResult.tradeEntity()));
-                    leftQuantity -= tradeResult.tradeEntity().getTradeQuantity();
-                } else {
-                    log.debug("skip canceled order.");
-                }
-
-            }
-        } else if (tradingType.equals("5")) { // SELL -> 모의 투자는 BUY
-            while (leftQuantity > 0) {
-                var buyOrderDto = orderQueueRegistry.pollBuy(stockCode);
-                if (buyOrderDto == null) return;
-
-                if (buyOrderDto.orderPrice() < tradePrice) {
-                    orderQueueRegistry.orderEnqueue(buyOrderDto);
-                    return;
-                }
-
-                int executable = Math.min(leftQuantity, buyOrderDto.remainingQuantity());
-
-                var tradeResult = tradeExecutionService.executeBuyTrade(buyOrderDto, tradePrice, executable);
-
-                if (tradeResult != null) {
-
-                    int remainingQuantity = buyOrderDto.remainingQuantity() - executable;
-
-                    if (remainingQuantity > 0) {
-                        var reEnqueuedOrderDto = new OrderDto(buyOrderDto.orderId(),
-                                buyOrderDto.username(),
-                                buyOrderDto.stockCode(),
-                                buyOrderDto.orderType(),
-                                buyOrderDto.orderPrice(),
-                                buyOrderDto.orderQuantity(),
-                                remainingQuantity,
-                                OrderStatus.PARTIAL,
-                                buyOrderDto.orderTime());
-                        orderQueueRegistry.orderEnqueue(reEnqueuedOrderDto);
-                    }
-
-                    if (remainingQuantity == 0) {
-                        stockServerOrderResponseRepository.delete(buyOrderDto.username(), buyOrderDto.orderId());
-                    } else {
-                        stockServerOrderResponseRepository.update(tradeResult.tradeEntity().getUsername(),
-                                tradeResult.tradeEntity().getOrderId(),
-                                StockServerOrderResponseMessage.of(
-                                        buyOrderDto.orderId(),
-                                        buyOrderDto.username(),
-                                        buyOrderDto.stockCode(),
-                                        buyOrderDto.orderType(),
-                                        buyOrderDto.orderPrice(),
-                                        buyOrderDto.orderQuantity(),
-                                        remainingQuantity,
-                                        buyOrderDto.orderTime()
-                                ));
-                    }
-
-                    long tradeAmount = (long) buyOrderDto.orderPrice() * tradeResult.tradeEntity().getTradeQuantity();
-                    long differenceAmount = (long) (buyOrderDto.orderPrice() - tradeResult.tradeEntity().getTradePrice()) * tradeResult.tradeEntity().getTradeQuantity();
-
-                    boolean redisOk = tradeCommand.applyBuyTrade(
-                            tradeResult.tradeEntity().getUsername(),
-                            tradeResult.tradeEntity().getStockCode(),
-                            tradeResult.totalQuantity(),
-                            tradeResult.totalAmount()/tradeResult.totalQuantity(),
-                            tradeAmount,
-                            differenceAmount
-                    );
-
-                    if (!redisOk) {
-                        log.error("Redis buy command failed.");
-                    }
-
-                    tradeResponseEventPublisher.publish(TradeResponseEvent.fromEntity(tradeResult.tradeEntity()));
-                    leftQuantity -= tradeResult.tradeEntity().getTradeQuantity();
-                }
-
-            }
+        switch (tradingType) {
+            case "1" -> matchAndExecuteSellSide(stockCode, tradePrice, leftQuantity);
+            case "5" -> matchAndExecuteBuySide(stockCode, tradePrice, leftQuantity);
+            case "3", "" -> matchAndExecuteCallAuction(stockCode, tradePrice, leftQuantity);
         }
+    }
+
+    private void matchAndExecuteSellSide(String stockCode, int tradePrice, int leftQuantity) {
+
+        while (leftQuantity > 0) {
+
+            var sell = orderQueueRegistry.pollSell(stockCode);
+
+            if (sell == null) return;
+
+            if (sell.orderPrice() > tradePrice) {
+                orderQueueRegistry.orderEnqueue(sell);
+                return;
+            }
+
+            int executable = Math.min(leftQuantity, sell.remainingQuantity());
+
+            var tradeResult = tradeExecutionService.executeSellTrade(sell, tradePrice, executable);
+
+            if (tradeResult == null) {
+                log.info("skip canceled order.");
+                continue;
+            }
+
+            int remaining = sell.remainingQuantity() - executable;
+
+            finalizeOrderAfterExecution(sell, remaining);
+            finalizeSellExecution(sell, tradeResult, tradePrice, executable);
+
+            leftQuantity -= executable;
+        }
+    }
+
+    private void matchAndExecuteBuySide(String stockCode, int tradePrice, int leftQuantity) {
+
+        while (leftQuantity > 0) {
+
+            var buy = orderQueueRegistry.pollBuy(stockCode);
+
+            if (buy == null) return;
+
+            if (buy.orderPrice() < tradePrice) {
+                orderQueueRegistry.orderEnqueue(buy);
+                return;
+            }
+
+            int executable = Math.min(leftQuantity, buy.remainingQuantity());
+
+            var tradeResult = tradeExecutionService.executeBuyTrade(buy, tradePrice, executable);
+
+            if (tradeResult == null) {
+                log.info("skip canceled order.");
+                continue;
+            }
+
+            int remaining = buy.remainingQuantity() - executable;
+
+            finalizeOrderAfterExecution(buy, remaining);
+            finalizeBuyExecution(buy, tradeResult, tradePrice, executable);
+
+            leftQuantity -= executable;
+        }
+    }
+
+    private void matchAndExecuteCallAuction(String stockCode, int tradePrice, int leftQuantity) {
+
+        while (leftQuantity > 0) {
+
+            var buy = orderQueueRegistry.pollBuy(stockCode);
+            var sell = orderQueueRegistry.pollSell(stockCode);
+
+            if (buy == null || sell == null) {
+                if (buy != null) orderQueueRegistry.orderEnqueue(buy);
+                if (sell != null) orderQueueRegistry.orderEnqueue(sell);
+                break;
+            }
+
+            if (buy.orderPrice() < tradePrice || sell.orderPrice() > tradePrice) {
+                orderQueueRegistry.orderEnqueue(buy);
+                orderQueueRegistry.orderEnqueue(sell);
+                break;
+            }
+
+            int executable = Math.min(
+                    leftQuantity,
+                    Math.min(buy.remainingQuantity(), sell.remainingQuantity())
+            );
+
+            var sellResult = tradeExecutionService.executeSellTrade(sell, tradePrice, executable);
+
+            if (sellResult != null) {
+                int remaining = sell.remainingQuantity() - executable;
+                finalizeOrderAfterExecution(sell, remaining);
+                finalizeSellExecution(sell, sellResult, tradePrice, executable);
+            } else {
+                log.info("skip canceled order.");
+            }
+
+
+            var buyResult = tradeExecutionService.executeBuyTrade(buy, tradePrice, executable);
+
+            if (buyResult != null) {
+                int remaining = buy.remainingQuantity() - executable;
+                finalizeOrderAfterExecution(buy, remaining);
+                finalizeBuyExecution(buy, buyResult, tradePrice, executable);
+            } else {
+                log.info("skip canceled order.");
+            }
+
+            leftQuantity -= executable;
+        }
+    }
+
+    private void finalizeOrderAfterExecution(OrderDto order, int remainingQuantity) {
+
+        if (remainingQuantity > 0) {
+
+            orderQueueRegistry.orderEnqueue(
+                    new OrderDto(
+                            order.orderId(),
+                            order.username(),
+                            order.stockCode(),
+                            order.orderType(),
+                            order.orderPrice(),
+                            order.orderQuantity(),
+                            remainingQuantity,
+                            OrderStatus.PARTIAL,
+                            order.orderTime()
+                    )
+            );
+        }
+
+        if (remainingQuantity == 0) {
+            stockServerOrderResponseRepository.delete(
+                    order.username(),
+                    order.orderId()
+            );
+        } else {
+            stockServerOrderResponseRepository.update(
+                    order.username(),
+                    order.orderId(),
+                    StockServerOrderResponseMessage.of(
+                            order.orderId(),
+                            order.username(),
+                            order.stockCode(),
+                            order.orderType(),
+                            order.orderPrice(),
+                            order.orderQuantity(),
+                            remainingQuantity,
+                            order.orderTime()
+                    )
+            );
+        }
+    }
+
+    private void finalizeSellExecution(OrderDto sell, TradeResult result,
+                                     int tradePrice, int executable) {
+
+        long orderAmount = (long) sell.orderPrice() * executable;
+        long differenceAmount = (long) (tradePrice - sell.orderPrice()) * executable;
+
+        long avgPrice = result.totalQuantity() == 0
+                ? 0
+                : result.totalAmount() / result.totalQuantity();
+
+        boolean redisOk = tradeCommand.applySellTrade(
+                sell.username(),
+                sell.stockCode(),
+                result.totalQuantity(),
+                avgPrice,
+                orderAmount,
+                differenceAmount
+        );
+
+        if (!redisOk) {
+            log.error("Redis sell command failed.");
+        }
+
+        tradeResponseEventPublisher.publish(
+                TradeResponseEvent.fromEntity(result.tradeEntity())
+        );
+        accountUpdateEventPublisher.publish(sell.username());
+    }
+
+    private void finalizeBuyExecution(OrderDto buy, TradeResult result,
+                                    int tradePrice, int executable) {
+
+        long orderAmount = (long) buy.orderPrice() * executable;
+        long differenceAmount = (long) (buy.orderPrice() - tradePrice) * executable;
+
+        long avgPrice = result.totalQuantity() == 0
+                ? 0
+                : result.totalAmount() / result.totalQuantity();
+
+        boolean redisOk = tradeCommand.applyBuyTrade(
+                buy.username(),
+                buy.stockCode(),
+                result.totalQuantity(),
+                avgPrice,
+                orderAmount,
+                differenceAmount
+        );
+
+        if (!redisOk) {
+            log.error("Redis buy command failed.");
+        }
+
+        tradeResponseEventPublisher.publish(
+                TradeResponseEvent.fromEntity(result.tradeEntity())
+        );
+        accountUpdateEventPublisher.publish(buy.username());
     }
 }


### PR DESCRIPTION
이 작업은 동시 호가 체결 로직을 구현하고, 가독성을 위해 코드를 재구성한 작업이다.
어떤 동시 호가 로직을 사용할지는 #68 에서 결정하였다.

## 1. 매칭/정산/후처리 로직 분리 (코드 재구성)

기존에는 체결 처리, Redis 정산, event 발행, 주문 PQ 재삽입 등이 하나의 흐름 안에 혼재되어 있었다.
이번 작업에서 다음과 같이 책임을 분리했다.

### 1) 주문 후처리 분리
- 잔량 존재 여부에 따라
  - 부분 체결 -> 주문 PQ 재삽입 + 저장소 상태 업데이트
  - 완전 체결 -> 저장소에서 제거
- 주문 상태(PARTIAL/완료) 처리 로직을 명확히 분리
- 주문 PQ 관리와 응답 저장소 업데이트를 일관된 정책으로 정리

### 2) 매수/매도 정산 로직 분리
- 매수 정산 / 매도 정산을 각각 독립 처리
- 평균 체결가 계산 로직 명확화
- Redis 커맨드 실패 시 로그 처리
- 체결 event 발행과 계좌 업데이트 이벤트 발행을 정산 이후로 통일

## 2. 동시 호가(Call Auction) 체결 로직 구현

동시 호가는 외부 API에서 확정된 체결 가격(tradePrice)과 체결 가능 수량(leftQuantity)을 기준으로 주문을 소진하는 방식으로 동작하게 하였다.
이와 같은 로직으로 결정하게 된 배경은 #68 에서 다루었다.

## 3. 동시호가 매칭 처리 흐름

### 1) 체결 가능 수량 기준 반복

- 전달 받은 체결 가능 수량이 0보다 큰 동안 반복
- 외부에서 확정된 총 체결 수량을 초과하지 않도록 제한

### 2) 매수/매도 주문 PQ 선두 주문 추출

- 매수 주문 PQ에서 주문 1건 추출
- 매도 주문 PQ에서 주문 1건 추출
- 주문 PQ는 가격/시간 우선 정책에 따라 정렬되어 있음

### 3) 주문 존재 여부 검증

- 매수 또는 매도 중 하나라도 존재하지 않으면 즉시 종료
- 존재하는 주문은 다시 주문 PQ에 복원

동시 호가는 양측 주문이 동시에 존재해야 체결이 가능하다.

### 4) 가격 조건 검증

다음 조건을 모두 만족해야 체결 진행:

- 매수 주문 가격 ≥ 체결 가격
- 매도 주문 가격 ≤ 체결 가격

조건 불만족 시:

- 두 주문을 다시 주문 PQ에 삽입
- 추가 탐색 없이 즉시 종료

### 5) 체결 수량 계산

체결 수량은 다음 중 최소값:

- 남은 체결 가능 수량
- 매수 주문 잔량
- 매도 주문 잔량

이를 통해:

- 총 체결 가능 수량 초과 방지
- 각 주문 잔량 초과 방지

### 6) 매도 정산 처리

- 체결 수량 기준 매도 주문 정산
- 평균 체결가 계산
- Redis 매도 체결 커맨드 호출
- 체결 이벤트 발행
- 계좌 업데이트 이벤트 발행
- 잔량에 따라 부분 체결 또는 완료 처리

### 7) 매수 정산 처리

- 매도와 동일한 흐름으로 매수 정산 처리
- 체결가와 주문가 차액 정산
- 잔량에 따른 상태 반영

### 8) 남은 체결 수량 차감

- 체결 수량만큼 차감
- 0이 되면 매칭 종료

This closes #68 