### PR TITLE
50. CORS 설정(Backend)

### DIFF
--- a/backend/src/main/java/arile/toy/stocksystem/bffserver/security/config/SecurityConfig.java
+++ b/backend/src/main/java/arile/toy/stocksystem/bffserver/security/config/SecurityConfig.java
@@ -11,6 +11,11 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -18,6 +23,18 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/v1/**", configuration);
+        return source;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
이 작업은 FE-BE 연동을 위한 CORS 를 설정한 작업이다.

로컬 FE 개발 서버(http://localhost:5173, http://127.0.0.1:5173)를 임시적으로 허용하며, GET, POST, PUT, DELETE, PATCH method를 허용한다.
모든 헤더 허용 및 자격 증명 포함 요청 허용한다.

This closes #106 