### PR TITLE
56. Redis Streams 재처리 로직 구현

### DIFF
--- a/backend/src/main/java/arile/toy/stocksystem/stockserver/autocancel/event/subscriber/RedisAutoCancelRequestEventConsumer.java
+++ b/backend/src/main/java/arile/toy/stocksystem/stockserver/autocancel/event/subscriber/RedisAutoCancelRequestEventConsumer.java
@@ -6,12 +6,14 @@ import arile.toy.stocksystem.stockserver.market.phase.StockServerMarketPhaseRegi
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +40,9 @@ public class RedisAutoCancelRequestEventConsumer {
     private final String consumerName =
             "stock-server" + UUID.randomUUID();
 
+    private static final long RETRY_IDLE_MILLIS = 10000;
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Scheduled(fixedDelay = 100)
     public void consume() {
         String streamKey = prefix + "-" + shardIndex;
@@ -57,23 +62,137 @@ public class RedisAutoCancelRequestEventConsumer {
 
         for (MapRecord<String, Object, Object> record : records) {
             try {
+
+                Map<Object, Object> value = record.getValue();
+
+                String type = (String) value.get("type");
+                if (!"AUTO_CANCEL_CREATED".equals(type)) {
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                String recordId = record.getId().getValue();
+                String status = getStatus(recordId);
+
+                if ("DONE".equals(status)) {
+                    log.warn("Duplicate DONE skip recordId={}", recordId);
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                if ("PROCESSING".equals(status)) {
+                    log.warn("Still PROCESSING recordId={}", recordId);
+                    continue;
+                }
+
+                if (!tryStartProcess(recordId)) {
+                    continue;
+                }
+
                 handle(record);
+
+                markProcessed(recordId);
+
                 streamRedisTemplate.opsForStream()
                         .acknowledge(streamKey, group, record.getId());
+
             } catch (Exception e) {
                 log.error("Failed to process {}", record.getId(), e);
             }
         }
-        // Todo: 재처리 과정
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void retry() {
+        String streamKey = prefix + "-" + shardIndex;
+        retryPending(streamKey);
+    }
+
+    private void retryPending(String streamKey) {
+
+        PendingMessages pendingMessages =
+                streamRedisTemplate.opsForStream()
+                        .pending(streamKey, group, Range.unbounded(), 20);
+
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return;
+        }
+
+        for (PendingMessage msg : pendingMessages) {
+
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < RETRY_IDLE_MILLIS) {
+                continue;
+            }
+
+            List<MapRecord<String, Object, Object>> claimed =
+                    streamRedisTemplate.opsForStream().claim(
+                            streamKey,
+                            group,
+                            consumerName,
+                            Duration.ofMillis(RETRY_IDLE_MILLIS),
+                            msg.getId()
+                    );
+
+            for (MapRecord<String, Object, Object> record : claimed) {
+                processRetry(streamKey, record);
+            }
+        }
+    }
+
+    private void processRetry(String streamKey, MapRecord<String, Object, Object> record) {
+
+        String recordId = record.getId().getValue();
+
+        try {
+            String status = getStatus(recordId);
+
+            if ("DONE".equals(status)) {
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+                return;
+            }
+
+            if ("PROCESSING".equals(status)) {
+                return;
+            }
+
+            if (!tryStartProcess(recordId)) {
+                return;
+            }
+
+            handle(record);
+
+            markProcessed(recordId);
+
+            streamRedisTemplate.opsForStream()
+                    .acknowledge(streamKey, group, record.getId());
+
+            clearRetryCount(record);
+
+        } catch (Exception e) {
+
+            int retryCount = getRetryCount(record);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                moveToDLQ(record);
+
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+
+                clearRetryCount(record);
+
+            } else {
+                increaseRetryCount(record);
+            }
+
+            log.error("Retry failed {}", record.getId(), e);
+        }
     }
 
     private void handle(MapRecord<String, Object, Object> record) {
         Map<Object, Object> value = record.getValue();
-
-        String type = (String) value.get("type");
-        if (!"AUTO_CANCEL_CREATED".equals(type)) {
-            return;
-        }
 
         Object autoOrderIdObj = value.get("autoOrderId");
         Long autoOrderId = null;
@@ -95,5 +214,72 @@ public class RedisAutoCancelRequestEventConsumer {
         log.info("Processing cancel autoOrderId: {} for stockCode {}", autoOrderId, stockCode);
 
         autoCancelService.registerAutoCancel(AutoCancelRequestEvent.of(autoOrderId, stockCode));
+    }
+
+    private String retryKey(RecordId id) {
+        return "retry:" + id.getValue();
+    }
+
+    private int getRetryCount(MapRecord<String, Object, Object> record) {
+        Object val = streamRedisTemplate.opsForValue()
+                .get(retryKey(record.getId()));
+        return val == null ? 0 : Integer.parseInt(val.toString());
+    }
+
+    private void increaseRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.opsForValue()
+                .increment(retryKey(record.getId()));
+    }
+
+    private void clearRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.delete(retryKey(record.getId()));
+    }
+
+    private void moveToDLQ(MapRecord<String, Object, Object> record) {
+
+        Map<String, Object> dlqData = new HashMap<>();
+        dlqData.put("original", record.getValue());
+        dlqData.put("failedAt", System.currentTimeMillis());
+        dlqData.put("recordId", record.getId().getValue());
+
+        streamRedisTemplate.opsForStream().add(
+                StreamRecords.mapBacked(dlqData)
+                        .withStreamKey("auto-cancel-dlq")
+        );
+    }
+
+    private String processedKey(String recordId) {
+        return "processed:autoCancel:" + recordId;
+    }
+
+    private boolean tryStartProcess(String recordId) {
+        if (recordId == null) return false;
+
+        Boolean success = streamRedisTemplate.opsForValue()
+                .setIfAbsent(
+                        processedKey(recordId),
+                        "PROCESSING",
+                        Duration.ofMinutes(5)
+                );
+
+        return Boolean.TRUE.equals(success);
+    }
+
+    private void markProcessed(String recordId) {
+        streamRedisTemplate.opsForValue()
+                .set(
+                        processedKey(recordId),
+                        "DONE",
+                        Duration.ofHours(24)
+                );
+    }
+
+    private String getStatus(String recordId) {
+        if (recordId == null) return null;
+
+        Object val = streamRedisTemplate.opsForValue()
+                .get(processedKey(recordId));
+
+        return val == null ? null : val.toString();
     }
 }

--- a/backend/src/main/java/arile/toy/stocksystem/stockserver/autoorder/event/subscriber/RedisAutoOrderRequestEventConsumer.java
+++ b/backend/src/main/java/arile/toy/stocksystem/stockserver/autoorder/event/subscriber/RedisAutoOrderRequestEventConsumer.java
@@ -7,12 +7,14 @@ import arile.toy.stocksystem.stockserver.market.phase.StockServerMarketPhaseRegi
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +40,9 @@ public class RedisAutoOrderRequestEventConsumer {
     private final String consumerName =
             "stock-server" + UUID.randomUUID();
 
+    private static final long RETRY_IDLE_MILLIS = 10000;
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Scheduled(fixedDelay = 100)
     public void consume() {
         String streamKey = prefix + "-" + shardIndex;
@@ -57,23 +62,136 @@ public class RedisAutoOrderRequestEventConsumer {
 
         for (MapRecord<String, Object, Object> record : records) {
             try {
+
+                Map<Object, Object> value = record.getValue();
+
+                String type = (String) value.get("type");
+                if (!"AUTO_ORDER_CREATED".equals(type)) {
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                String recordId = record.getId().getValue();
+                String status = getStatus(recordId);
+
+                if ("DONE".equals(status)) {
+                    log.warn("Duplicate DONE skip recordId={}", recordId);
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                if ("PROCESSING".equals(status)) {
+                    log.warn("Still PROCESSING recordId={}", recordId);
+                    continue;
+                }
+
+                if (!tryStartProcess(recordId)) {
+                    continue;
+                }
+
                 handle(record);
+
+                markProcessed(recordId);
+
                 streamRedisTemplate.opsForStream()
                         .acknowledge(streamKey, group, record.getId());
             } catch (Exception e) {
                 log.error("Failed to process {}", record.getId(), e);
             }
         }
-        // Todo: 재처리 과정
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void retry() {
+        String streamKey = prefix + "-" + shardIndex;
+        retryPending(streamKey);
+    }
+
+    private void retryPending(String streamKey) {
+
+        PendingMessages pendingMessages =
+                streamRedisTemplate.opsForStream()
+                        .pending(streamKey, group, Range.unbounded(), 20);
+
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return;
+        }
+
+        for (PendingMessage msg : pendingMessages) {
+
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < RETRY_IDLE_MILLIS) {
+                continue;
+            }
+
+            List<MapRecord<String, Object, Object>> claimed =
+                    streamRedisTemplate.opsForStream().claim(
+                            streamKey,
+                            group,
+                            consumerName,
+                            Duration.ofMillis(RETRY_IDLE_MILLIS),
+                            msg.getId()
+                    );
+
+            for (MapRecord<String, Object, Object> record : claimed) {
+                processRetry(streamKey, record);
+            }
+        }
+    }
+
+    private void processRetry(String streamKey, MapRecord<String, Object, Object> record) {
+
+        String recordId = record.getId().getValue();
+
+        try {
+            String status = getStatus(recordId);
+
+            if ("DONE".equals(status)) {
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+                return;
+            }
+
+            if ("PROCESSING".equals(status)) {
+                return;
+            }
+
+            if (!tryStartProcess(recordId)) {
+                return;
+            }
+
+            handle(record);
+
+            markProcessed(recordId);
+
+            streamRedisTemplate.opsForStream()
+                    .acknowledge(streamKey, group, record.getId());
+
+            clearRetryCount(record);
+
+        } catch (Exception e) {
+
+            int retryCount = getRetryCount(record);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                moveToDLQ(record);
+
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+
+                clearRetryCount(record);
+
+            } else {
+                increaseRetryCount(record);
+            }
+
+            log.error("Retry failed {}", record.getId(), e);
+        }
     }
 
     private void handle(MapRecord<String, Object, Object> record) {
         Map<Object, Object> value = record.getValue();
-
-        String type = (String) value.get("type");
-        if (!"AUTO_ORDER_CREATED".equals(type)) {
-            return;
-        }
 
         String username = (String) value.get("username");
         String stockCode = (String) value.get("stockCode");
@@ -118,5 +236,72 @@ public class RedisAutoOrderRequestEventConsumer {
 
         autoOrderService.registerAutoOrder(StockServerAutoOrderRequestEvent
                 .of(username, stockCode, autoOrderType, triggerPrice, orderPrice, orderQuantity));
+    }
+
+    private String retryKey(RecordId id) {
+        return "retry:" + id.getValue();
+    }
+
+    private int getRetryCount(MapRecord<String, Object, Object> record) {
+        Object val = streamRedisTemplate.opsForValue()
+                .get(retryKey(record.getId()));
+        return val == null ? 0 : Integer.parseInt(val.toString());
+    }
+
+    private void increaseRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.opsForValue()
+                .increment(retryKey(record.getId()));
+    }
+
+    private void clearRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.delete(retryKey(record.getId()));
+    }
+
+    private void moveToDLQ(MapRecord<String, Object, Object> record) {
+
+        Map<String, Object> dlqData = new HashMap<>();
+        dlqData.put("original", record.getValue());
+        dlqData.put("failedAt", System.currentTimeMillis());
+        dlqData.put("recordId", record.getId().getValue());
+
+        streamRedisTemplate.opsForStream().add(
+                StreamRecords.mapBacked(dlqData)
+                        .withStreamKey("auto-order-dlq")
+        );
+    }
+
+    private String processedKey(String recordId) {
+        return "processed:autoOrder:" + recordId;
+    }
+
+    private boolean tryStartProcess(String recordId) {
+        if (recordId == null) return false;
+
+        Boolean success = streamRedisTemplate.opsForValue()
+                .setIfAbsent(
+                        processedKey(recordId),
+                        "PROCESSING",
+                        Duration.ofMinutes(5)
+                );
+
+        return Boolean.TRUE.equals(success);
+    }
+
+    private void markProcessed(String recordId) {
+        streamRedisTemplate.opsForValue()
+                .set(
+                        processedKey(recordId),
+                        "DONE",
+                        Duration.ofHours(24)
+                );
+    }
+
+    private String getStatus(String recordId) {
+        if (recordId == null) return null;
+
+        Object val = streamRedisTemplate.opsForValue()
+                .get(processedKey(recordId));
+
+        return val == null ? null : val.toString();
     }
 }

--- a/backend/src/main/java/arile/toy/stocksystem/stockserver/cancel/event/subscriber/RedisCancelRequestEventConsumer.java
+++ b/backend/src/main/java/arile/toy/stocksystem/stockserver/cancel/event/subscriber/RedisCancelRequestEventConsumer.java
@@ -6,12 +6,14 @@ import arile.toy.stocksystem.stockserver.market.phase.StockServerMarketPhaseRegi
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +40,9 @@ public class RedisCancelRequestEventConsumer {
     private final String consumerName =
             "stock-server" + UUID.randomUUID();
 
+    private static final long RETRY_IDLE_MILLIS = 10000;
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Scheduled(fixedDelay = 100)
     public void consume() {
         String streamKey = prefix + "-" + shardIndex;
@@ -57,23 +62,136 @@ public class RedisCancelRequestEventConsumer {
 
         for (MapRecord<String, Object, Object> record : records) {
             try {
+
+                Map<Object, Object> value = record.getValue();
+
+                String type = (String) value.get("type");
+                if (!"CANCEL_CREATED".equals(type)) {
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                String recordId = record.getId().getValue();
+                String status = getStatus(recordId);
+
+                if ("DONE".equals(status)) {
+                    log.warn("Duplicate DONE skip recordId={}", recordId);
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                if ("PROCESSING".equals(status)) {
+                    log.warn("Still PROCESSING recordId={}", recordId);
+                    continue;
+                }
+
+                if (!tryStartProcess(recordId)) {
+                    continue;
+                }
+
                 handle(record);
+
+                markProcessed(recordId);
+
                 streamRedisTemplate.opsForStream()
                         .acknowledge(streamKey, group, record.getId());
             } catch (Exception e) {
                 log.error("Failed to process {}", record.getId(), e);
             }
         }
-        // Todo: 재처리 과정
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void retry() {
+        String streamKey = prefix + "-" + shardIndex;
+        retryPending(streamKey);
+    }
+
+    private void retryPending(String streamKey) {
+
+        PendingMessages pendingMessages =
+                streamRedisTemplate.opsForStream()
+                        .pending(streamKey, group, Range.unbounded(), 20);
+
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return;
+        }
+
+        for (PendingMessage msg : pendingMessages) {
+
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < RETRY_IDLE_MILLIS) {
+                continue;
+            }
+
+            List<MapRecord<String, Object, Object>> claimed =
+                    streamRedisTemplate.opsForStream().claim(
+                            streamKey,
+                            group,
+                            consumerName,
+                            Duration.ofMillis(RETRY_IDLE_MILLIS),
+                            msg.getId()
+                    );
+
+            for (MapRecord<String, Object, Object> record : claimed) {
+                processRetry(streamKey, record);
+            }
+        }
+    }
+
+    private void processRetry(String streamKey, MapRecord<String, Object, Object> record) {
+
+        String recordId = record.getId().getValue();
+
+        try {
+            String status = getStatus(recordId);
+
+            if ("DONE".equals(status)) {
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+                return;
+            }
+
+            if ("PROCESSING".equals(status)) {
+                return;
+            }
+
+            if (!tryStartProcess(recordId)) {
+                return;
+            }
+
+            handle(record);
+
+            markProcessed(recordId);
+
+            streamRedisTemplate.opsForStream()
+                    .acknowledge(streamKey, group, record.getId());
+
+            clearRetryCount(record);
+
+        } catch (Exception e) {
+
+            int retryCount = getRetryCount(record);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                moveToDLQ(record);
+
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+
+                clearRetryCount(record);
+
+            } else {
+                increaseRetryCount(record);
+            }
+
+            log.error("Retry failed {}", record.getId(), e);
+        }
     }
 
     private void handle(MapRecord<String, Object, Object> record) {
         Map<Object, Object> value = record.getValue();
-
-        String type = (String) value.get("type");
-        if (!"CANCEL_CREATED".equals(type)) {
-            return;
-        }
 
         Object orderIdObj = value.get("orderId");
         Long orderId = null;
@@ -95,5 +213,72 @@ public class RedisCancelRequestEventConsumer {
         log.info("Processing cancel orderId: {} for stockCode {}", orderId, stockCode);
 
         cancelService.registerCancel(CancelRequestEvent.of(orderId, stockCode));
+    }
+
+    private String retryKey(RecordId id) {
+        return "retry:" + id.getValue();
+    }
+
+    private int getRetryCount(MapRecord<String, Object, Object> record) {
+        Object val = streamRedisTemplate.opsForValue()
+                .get(retryKey(record.getId()));
+        return val == null ? 0 : Integer.parseInt(val.toString());
+    }
+
+    private void increaseRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.opsForValue()
+                .increment(retryKey(record.getId()));
+    }
+
+    private void clearRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.delete(retryKey(record.getId()));
+    }
+
+    private void moveToDLQ(MapRecord<String, Object, Object> record) {
+
+        Map<String, Object> dlqData = new HashMap<>();
+        dlqData.put("original", record.getValue());
+        dlqData.put("failedAt", System.currentTimeMillis());
+        dlqData.put("recordId", record.getId().getValue());
+
+        streamRedisTemplate.opsForStream().add(
+                StreamRecords.mapBacked(dlqData)
+                        .withStreamKey("cancel-dlq")
+        );
+    }
+
+    private String processedKey(String recordId) {
+        return "processed:cancel:" + recordId;
+    }
+
+    private boolean tryStartProcess(String recordId) {
+        if (recordId == null) return false;
+
+        Boolean success = streamRedisTemplate.opsForValue()
+                .setIfAbsent(
+                        processedKey(recordId),
+                        "PROCESSING",
+                        Duration.ofMinutes(5)
+                );
+
+        return Boolean.TRUE.equals(success);
+    }
+
+    private void markProcessed(String recordId) {
+        streamRedisTemplate.opsForValue()
+                .set(
+                        processedKey(recordId),
+                        "DONE",
+                        Duration.ofHours(24)
+                );
+    }
+
+    private String getStatus(String recordId) {
+        if (recordId == null) return null;
+
+        Object val = streamRedisTemplate.opsForValue()
+                .get(processedKey(recordId));
+
+        return val == null ? null : val.toString();
     }
 }

--- a/backend/src/main/java/arile/toy/stocksystem/stockserver/order/event/subscriber/RedisOrderRequestEventConsumer.java
+++ b/backend/src/main/java/arile/toy/stocksystem/stockserver/order/event/subscriber/RedisOrderRequestEventConsumer.java
@@ -7,12 +7,14 @@ import arile.toy.stocksystem.stockserver.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +40,9 @@ public class RedisOrderRequestEventConsumer {
     private final String consumerName =
             "stock-server" + UUID.randomUUID();
 
+    private static final long RETRY_IDLE_MILLIS = 10000;
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Scheduled(fixedDelay = 100)
     public void consume() {
         String streamKey = prefix + "-" + shardIndex;
@@ -57,24 +62,135 @@ public class RedisOrderRequestEventConsumer {
 
         for (MapRecord<String, Object, Object> record : records) {
             try {
+
+                Map<Object, Object> value = record.getValue();
+
+                String type = (String) value.get("type");
+                if (!"ORDER_CREATED".equals(type)) {
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                String recordId = record.getId().getValue();
+                String status = getStatus(recordId);
+
+                if ("DONE".equals(status)) {
+                    log.warn("Duplicate DONE skip recordId={}", recordId);
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                if ("PROCESSING".equals(status)) {
+                    log.warn("Still PROCESSING recordId={}", recordId);
+                    continue;
+                }
+
+                if (!tryStartProcess(recordId)) {
+                    continue;
+                }
+
                 handle(record);
+
+                markProcessed(recordId);
+
                 streamRedisTemplate.opsForStream()
                         .acknowledge(streamKey, group, record.getId());
             } catch (Exception e) {
                 log.error("Failed to process {}", record.getId(), e);
             }
         }
+    }
 
-        // Todo: 재처리 과정
+    @Scheduled(fixedDelay = 1000)
+    public void retry() {
+        String streamKey = prefix + "-" + shardIndex;
+        retryPending(streamKey);
+    }
+
+    private void retryPending(String streamKey) {
+
+        PendingMessages pendingMessages =
+                streamRedisTemplate.opsForStream()
+                        .pending(streamKey, group, Range.unbounded(), 20);
+
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return;
+        }
+
+        for (PendingMessage msg : pendingMessages) {
+
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < RETRY_IDLE_MILLIS) {
+                continue;
+            }
+
+            List<MapRecord<String, Object, Object>> claimed =
+                    streamRedisTemplate.opsForStream().claim(
+                            streamKey,
+                            group,
+                            consumerName,
+                            Duration.ofMillis(RETRY_IDLE_MILLIS),
+                            msg.getId()
+                    );
+
+            for (MapRecord<String, Object, Object> record : claimed) {
+                processRetry(streamKey, record);
+            }
+        }
+    }
+
+    private void processRetry(String streamKey, MapRecord<String, Object, Object> record) {
+
+        String recordId = record.getId().getValue();
+        try {
+            String status = getStatus(recordId);
+
+            if ("DONE".equals(status)) {
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+                return;
+            }
+
+            if ("PROCESSING".equals(status)) {
+                return;
+            }
+
+            if (!tryStartProcess(recordId)) {
+                return;
+            }
+
+            handle(record);
+
+            markProcessed(recordId);
+
+            streamRedisTemplate.opsForStream()
+                    .acknowledge(streamKey, group, record.getId());
+
+            clearRetryCount(record);
+
+        } catch (Exception e) {
+
+            int retryCount = getRetryCount(record);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                moveToDLQ(record);
+
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+
+                clearRetryCount(record);
+
+            } else {
+                increaseRetryCount(record);
+            }
+
+            log.error("Retry failed {}", record.getId(), e);
+        }
     }
 
     private void handle(MapRecord<String, Object, Object> record) {
         Map<Object, Object> value = record.getValue();
-
-        String type = (String) value.get("type");
-        if (!"ORDER_CREATED".equals(type)) {
-            return;
-        }
 
         String username = (String) value.get("username");
         String stockCode = (String) value.get("stockCode");
@@ -110,5 +226,72 @@ public class RedisOrderRequestEventConsumer {
 
         orderService.registerOrder(StockServerOrderRequestEvent
                 .of(username, stockCode, orderType, orderPrice, orderQuantity), false);
+    }
+
+    private String retryKey(RecordId id) {
+        return "retry:" + id.getValue();
+    }
+
+    private int getRetryCount(MapRecord<String, Object, Object> record) {
+        Object val = streamRedisTemplate.opsForValue()
+                .get(retryKey(record.getId()));
+        return val == null ? 0 : Integer.parseInt(val.toString());
+    }
+
+    private void increaseRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.opsForValue()
+                .increment(retryKey(record.getId()));
+    }
+
+    private void clearRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.delete(retryKey(record.getId()));
+    }
+
+    private void moveToDLQ(MapRecord<String, Object, Object> record) {
+
+        Map<String, Object> dlqData = new HashMap<>();
+        dlqData.put("original", record.getValue());
+        dlqData.put("failedAt", System.currentTimeMillis());
+        dlqData.put("recordId", record.getId().getValue());
+
+        streamRedisTemplate.opsForStream().add(
+                StreamRecords.mapBacked(dlqData)
+                        .withStreamKey("order-dlq")
+        );
+    }
+
+    private String processedKey(String recordId) {
+        return "processed:order:" + recordId;
+    }
+
+    private boolean tryStartProcess(String recordId) {
+        if (recordId == null) return false;
+
+        Boolean success = streamRedisTemplate.opsForValue()
+                .setIfAbsent(
+                        processedKey(recordId),
+                        "PROCESSING",
+                        Duration.ofMinutes(5)
+                );
+
+        return Boolean.TRUE.equals(success);
+    }
+
+    private void markProcessed(String recordId) {
+        streamRedisTemplate.opsForValue()
+                .set(
+                        processedKey(recordId),
+                        "DONE",
+                        Duration.ofHours(24)
+                );
+    }
+
+    private String getStatus(String recordId) {
+        if (recordId == null) return null;
+
+        Object val = streamRedisTemplate.opsForValue()
+                .get(processedKey(recordId));
+
+        return val == null ? null : val.toString();
     }
 }

--- a/backend/src/main/java/arile/toy/stocksystem/stockserver/useraccount/event/subscriber/RedisUserCreatedEventConsumer.java
+++ b/backend/src/main/java/arile/toy/stocksystem/stockserver/useraccount/event/subscriber/RedisUserCreatedEventConsumer.java
@@ -3,12 +3,14 @@ package arile.toy.stocksystem.stockserver.useraccount.event.subscriber;
 import arile.toy.stocksystem.stockserver.useraccount.service.UserAccountService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -37,6 +39,9 @@ public class RedisUserCreatedEventConsumer {
         this.group = group;
     }
 
+    private static final long RETRY_IDLE_MILLIS = 10000;
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Scheduled(fixedDelay = 100)
     public void consume() {
 
@@ -55,29 +60,208 @@ public class RedisUserCreatedEventConsumer {
 
         for (MapRecord<String, Object, Object> record : records) {
             try {
+
+                Map<Object, Object> value = record.getValue();
+
+                String type = (String) value.get("type");
+                if (!"USER_CREATED".equals(type)) {
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                String recordId = record.getId().getValue();
+                String status = getStatus(recordId);
+
+                if ("DONE".equals(status)) {
+                    log.warn("Duplicate DONE skip recordId={}", recordId);
+                    streamRedisTemplate.opsForStream()
+                            .acknowledge(streamKey, group, record.getId());
+                    continue;
+                }
+
+                if ("PROCESSING".equals(status)) {
+                    log.warn("Still PROCESSING recordId={}", recordId);
+                    continue;
+                }
+
+                if (!tryStartProcess(recordId)) {
+                    continue;
+                }
+
                 handle(record);
+
+                markProcessed(recordId);
+
                 streamRedisTemplate.opsForStream().acknowledge(
                         streamKey, group, record.getId()
                 );
             } catch (Exception e) {
                 log.error("Failed to process event {}", record.getId(), e);
-                // Todo: 재처리 과정
             }
+        }
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void retry() {
+        retryPending(streamKey);
+    }
+
+    private void retryPending(String streamKey) {
+
+        PendingMessages pendingMessages =
+                streamRedisTemplate.opsForStream()
+                        .pending(streamKey, group, Range.unbounded(), 20);
+
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return;
+        }
+
+        for (PendingMessage msg : pendingMessages) {
+
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < RETRY_IDLE_MILLIS) {
+                continue;
+            }
+
+            List<MapRecord<String, Object, Object>> claimed =
+                    streamRedisTemplate.opsForStream().claim(
+                            streamKey,
+                            group,
+                            consumerName,
+                            Duration.ofMillis(RETRY_IDLE_MILLIS),
+                            msg.getId()
+                    );
+
+            for (MapRecord<String, Object, Object> record : claimed) {
+                processRetry(streamKey, record);
+            }
+        }
+    }
+
+    private void processRetry(String streamKey, MapRecord<String, Object, Object> record) {
+
+        String recordId = record.getId().getValue();
+
+        try {
+            String status = getStatus(recordId);
+
+            if ("DONE".equals(status)) {
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+                return;
+            }
+
+            if ("PROCESSING".equals(status)) {
+                return;
+            }
+
+            if (!tryStartProcess(recordId)) {
+                return;
+            }
+
+            handle(record);
+
+            markProcessed(recordId);
+
+            streamRedisTemplate.opsForStream()
+                    .acknowledge(streamKey, group, record.getId());
+
+            clearRetryCount(record);
+
+        } catch (Exception e) {
+
+            int retryCount = getRetryCount(record);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                moveToDLQ(record);
+
+                streamRedisTemplate.opsForStream()
+                        .acknowledge(streamKey, group, record.getId());
+
+                clearRetryCount(record);
+
+            } else {
+                increaseRetryCount(record);
+            }
+
+            log.error("Retry failed {}", record.getId(), e);
         }
     }
 
     private void handle(MapRecord<String, Object, Object> record) {
         Map<Object, Object> value = record.getValue();
 
-        String type = (String) value.get("type");
-        if (!"USER_CREATED".equals(type)) {
-            return;
-        }
-
         String username = (String) value.get("username");
 
         userAccountService.createAccountIfAbsent(username);
 
         log.info("Account created for username={}", username);
+    }
+
+    private String retryKey(RecordId id) {
+        return "retry:" + id.getValue();
+    }
+
+    private int getRetryCount(MapRecord<String, Object, Object> record) {
+        Object val = streamRedisTemplate.opsForValue()
+                .get(retryKey(record.getId()));
+        return val == null ? 0 : Integer.parseInt(val.toString());
+    }
+
+    private void increaseRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.opsForValue()
+                .increment(retryKey(record.getId()));
+    }
+
+    private void clearRetryCount(MapRecord<String, Object, Object> record) {
+        streamRedisTemplate.delete(retryKey(record.getId()));
+    }
+
+    private void moveToDLQ(MapRecord<String, Object, Object> record) {
+
+        Map<String, Object> dlqData = new HashMap<>();
+        dlqData.put("original", record.getValue());
+        dlqData.put("failedAt", System.currentTimeMillis());
+        dlqData.put("recordId", record.getId().getValue());
+
+        streamRedisTemplate.opsForStream().add(
+                StreamRecords.mapBacked(dlqData)
+                        .withStreamKey("user-create-dlq")
+        );
+    }
+
+    private String processedKey(String recordId) {
+        return "processed:user-create:" + recordId;
+    }
+
+    private boolean tryStartProcess(String recordId) {
+        if (recordId == null) return false;
+
+        Boolean success = streamRedisTemplate.opsForValue()
+                .setIfAbsent(
+                        processedKey(recordId),
+                        "PROCESSING",
+                        Duration.ofMinutes(5)
+                );
+
+        return Boolean.TRUE.equals(success);
+    }
+
+    private void markProcessed(String recordId) {
+        streamRedisTemplate.opsForValue()
+                .set(
+                        processedKey(recordId),
+                        "DONE",
+                        Duration.ofHours(24)
+                );
+    }
+
+    private String getStatus(String recordId) {
+        if (recordId == null) return null;
+
+        Object val = streamRedisTemplate.opsForValue()
+                .get(processedKey(recordId));
+
+        return val == null ? null : val.toString();
     }
 }

--- a/backend/src/test/java/arile/toy/stocksystem/stockserver/autocancel/event/subscriber/RedisAutoCancelRequestEventConsumerTest.java
+++ b/backend/src/test/java/arile/toy/stocksystem/stockserver/autocancel/event/subscriber/RedisAutoCancelRequestEventConsumerTest.java
@@ -14,8 +14,10 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -100,8 +102,18 @@ class RedisAutoCancelRequestEventConsumerTest {
         RecordId recordId = RecordId.of("1-0");
         when(record.getId()).thenReturn(recordId);
 
+        ValueOperations<String, Object> valueOps = mock(ValueOperations.class);
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForStream()).thenReturn(streamOps);
+
         when(streamOps.read(any(Consumer.class), any(StreamReadOptions.class), any()))
                 .thenReturn(List.of(record));
+        when(streamOps.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+        when(valueOps.get(anyString())).thenReturn(null);
+        when(valueOps.setIfAbsent(anyString(), eq("PROCESSING"), any(Duration.class))).thenReturn(true);
+        doNothing().when(valueOps).set(anyString(), eq("DONE"), any(Duration.class));
 
         when(registry.isClosed("TEST")).thenReturn(false);
 

--- a/backend/src/test/java/arile/toy/stocksystem/stockserver/autoorder/event/subscriber/RedisAutoOrderRequestEventConsumerTest.java
+++ b/backend/src/test/java/arile/toy/stocksystem/stockserver/autoorder/event/subscriber/RedisAutoOrderRequestEventConsumerTest.java
@@ -15,8 +15,10 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -91,8 +93,18 @@ class RedisAutoOrderRequestEventConsumerTest {
         RecordId recordId = RecordId.of("1-0");
         when(record.getId()).thenReturn(recordId);
 
+        ValueOperations<String, Object> valueOps = mock(ValueOperations.class);
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForStream()).thenReturn(streamOps);
+
         when(streamOps.read(any(Consumer.class), any(StreamReadOptions.class), any()))
                 .thenReturn(List.of(record));
+        when(streamOps.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+        when(valueOps.get(anyString())).thenReturn(null);
+        when(valueOps.setIfAbsent(anyString(), eq("PROCESSING"), any(Duration.class))).thenReturn(true);
+        doNothing().when(valueOps).set(anyString(), eq("DONE"), any(Duration.class));
 
         when(registry.isClosed("TEST")).thenReturn(false);
 

--- a/backend/src/test/java/arile/toy/stocksystem/stockserver/cancel/event/subscriber/RedisCancelRequestEventConsumerTest.java
+++ b/backend/src/test/java/arile/toy/stocksystem/stockserver/cancel/event/subscriber/RedisCancelRequestEventConsumerTest.java
@@ -14,8 +14,10 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -82,8 +84,19 @@ class RedisCancelRequestEventConsumerTest {
         RecordId recordId = RecordId.of("1-0");
         when(record.getId()).thenReturn(recordId);
 
+        ValueOperations<String, Object> valueOps = mock(ValueOperations.class);
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForStream()).thenReturn(streamOps);
+
         when(streamOps.read(any(Consumer.class), any(StreamReadOptions.class), any()))
                 .thenReturn(List.of(record));
+        when(streamOps.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+        when(valueOps.get(anyString())).thenReturn(null);
+        when(valueOps.setIfAbsent(anyString(), eq("PROCESSING"), any(Duration.class))).thenReturn(true);
+        doNothing().when(valueOps).set(anyString(), eq("DONE"), any(Duration.class));
+
 
         when(registry.isClosed("TEST")).thenReturn(false);
 

--- a/backend/src/test/java/arile/toy/stocksystem/stockserver/order/event/subscriber/RedisOrderRequestEventConsumerTest.java
+++ b/backend/src/test/java/arile/toy/stocksystem/stockserver/order/event/subscriber/RedisOrderRequestEventConsumerTest.java
@@ -14,8 +14,10 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -85,8 +87,19 @@ class RedisOrderRequestEventConsumerTest {
         RecordId recordId = RecordId.of("1-0");
         when(record.getId()).thenReturn(recordId);
 
+        ValueOperations<String, Object> valueOps = mock(ValueOperations.class);
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForStream()).thenReturn(streamOps);
+
+
         when(streamOps.read(any(Consumer.class), any(StreamReadOptions.class), any()))
                 .thenReturn(List.of(record));
+        when(streamOps.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+        when(valueOps.get(anyString())).thenReturn(null);
+        when(valueOps.setIfAbsent(anyString(), eq("PROCESSING"), any(Duration.class))).thenReturn(true);
+        doNothing().when(valueOps).set(anyString(), eq("DONE"), any(Duration.class));
 
         when(registry.isClosed("TEST")).thenReturn(false);
 

--- a/backend/src/test/java/arile/toy/stocksystem/stockserver/useraccount/event/subscriber/RedisUserCreatedEventConsumerTest.java
+++ b/backend/src/test/java/arile/toy/stocksystem/stockserver/useraccount/event/subscriber/RedisUserCreatedEventConsumerTest.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import static org.mockito.Mockito.*;
@@ -22,6 +23,7 @@ import java.util.*;
 import static org.mockito.ArgumentMatchers.any;
 
 import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.HashMap;
 import java.util.List;
@@ -93,11 +95,23 @@ class RedisUserCreatedEventConsumerTest {
         RecordId recordId = RecordId.of("1-0");
         when(record.getId()).thenReturn(recordId);
 
+        ValueOperations<String, Object> valueOps = mock(ValueOperations.class);
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForStream()).thenReturn(streamOps);
+
+
         when(streamOps.read(
                 any(Consumer.class),
                 any(StreamReadOptions.class),
                 any()
         )).thenReturn(List.of(record));
+
+        when(streamOps.acknowledge(anyString(), anyString(), any(RecordId.class))).thenReturn(1L);
+
+        when(valueOps.get(anyString())).thenReturn(null);
+        when(valueOps.setIfAbsent(anyString(), eq("PROCESSING"), any(Duration.class))).thenReturn(true);
+        doNothing().when(valueOps).set(anyString(), eq("DONE"), any(Duration.class));
 
         // when
         consumer.consume();


### PR DESCRIPTION
이 작업은 Stock Server의 여러 Redis Streams Consumer(Order, Cancel, AutoOrder, AutoCancel, UserCreate)들의 재처리 로직을 구현한 작업이다.

## 1. 100ms 주기로 Redis Streams에서 주문 이벤트 소비
  - 샤드별 스트림에서 최대 10건 읽기
  - ORDER_CREATED 이벤트만 처리, 그 외 이벤트는 즉시 ACK
  - 이미 DONE 상태이거나 PROCESSING 중인 record는 skip
  - setIfAbsent로 PROCESSING 상태 설정 시도(동시성 제어)
  - 처리 가능한 record는 OrderService를 통해 주문 등록
  - 처리 완료 후 DONE 상태로 표시, TTL 24시간
  - 처리 완료 record는 Redis Streams에 ACK

## 2. 1000ms 주기로 재시도 메커니즘 구현
  - Redis Streams PEL(Pending Entries List) 조회, 최대 20건
    - PEL: 컨슈머가 아직 ACK하지 않은 메시지 목록
  - RETRY_IDLE_MILLIS 이상 대기한 메시지를 해당 consumer로 claim
  - claim된 메시지를 동시성 안전하게 재처리
  - record 재시도 횟수를 Redis에서 관리
  - MAX_RETRY_COUNT 초과 시 DLQ로 이동 후 ACK
  - 재시도 실패 시, 최대 횟수 미만이면 재시도 횟수 증가
  - 성공 처리 또는 DLQ 이동 시 재시도 횟수 초기화

## 3. handle()에서 주문 처리 로직 수행
  - username, stockCode, orderType, 가격, 수량 추출
  - 유효하지 않은 orderType은 skip
  - 장 종료된 경우 해당 주문 skip
  - OrderService로 주문 등록

## 4. Utility method 제공
  - retryKey / getRetryCount / increaseRetryCount / clearRetryCount
  - processedKey / tryStartProcess / markProcessed / getStatus
  - moveToDLQ: 재시도 최대치 초과 메시지는 DLQ로 이동

## 5. 동시성 및 장애 대비
  - PROCESSING 플래그 + TTL로 중복 처리 방지
  - 재시도 메커니즘으로 일시적 실패 대응
  - DLQ로 영구 실패 메시지 관리

This closes #121.